### PR TITLE
Adds Google Cloud RAD Security Connect Terraform Module

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,3 @@
+addReviewers: true
+reviewers:
+  - rad-security/engineering

--- a/.github/workflows/assign-bot.yml
+++ b/.github/workflows/assign-bot.yml
@@ -1,0 +1,10 @@
+name: 'Auto Assign'
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  add-reviews:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kentaro-m/auto-assign-action@v2.0.0

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,17 @@
+name: checks
+
+on:
+  pull_request:
+
+jobs:
+
+ pre-commit:
+   permissions:
+     contents: read
+   runs-on: ubuntu-latest
+   container: ksoc/terraform-toolkit:1.0.8
+   steps:
+     - name: clone repo
+       uses: actions/checkout@v4
+     - name: pre-commit checks
+       run: pre-commit-checks

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+      - master
+    paths:
+      - '**/*.tpl'
+      - '**/*.py'
+      - '**/*.tf'
+      - '.github/workflows/release.yml'
+      - 'README.md'
+
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - name: Release
+        uses: cycjimmy/semantic-release-action@v2
+        with:
+          semantic_version: 18.0.0
+          extra_plugins: |
+            @semantic-release/changelog@6.0.0
+            @semantic-release/git@10.0.0
+            conventional-changelog-conventionalcommits@4.6.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.0.1
+    hooks:
+      - id: fix-byte-order-marker
+      - id: check-case-conflict
+      - id: check-merge-conflict
+      - id: detect-aws-credentials
+        args: ['--allow-missing-credentials']
+      - id: detect-private-key
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+      - id: trailing-whitespace
+  - repo: https://github.com/antonbabenko/pre-commit-terraform.git
+    rev: v1.52.0
+    hooks:
+      - id: terraform_fmt
+      - id: terraform_docs
+  - repo: https://github.com/gruntwork-io/pre-commit
+    rev: v0.1.16
+    hooks:
+      - id: shellcheck

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,45 @@
+{
+  "branches": [
+    "main",
+    "master"
+  ],
+  "ci": false,
+  "plugins": [
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "conventionalcommits"
+      }
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "conventionalcommits"
+      }
+    ],
+    [
+      "@semantic-release/github",
+      {
+        "successComment": "This ${issue.pull_request ? 'PR is included' : 'issue has been resolved'} in version ${nextRelease.version} :tada:",
+        "labels": false,
+        "releasedLabels": false
+      }
+    ],
+    [
+      "@semantic-release/changelog",
+      {
+        "changelogFile": "CHANGELOG.md",
+        "changelogTitle": "# Changelog\n\nAll notable changes to this project will be documented in this file."
+      }
+    ],
+    [
+      "@semantic-release/git",
+      {
+        "assets": [
+          "CHANGELOG.md"
+        ],
+        "message": "chore(release): version ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+      }
+    ]
+  ]
+}

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @rad-security/engineering

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+initialise:
+	pre-commit install
+	pre-commit run -a
+
+changelog:
+	git-chglog -o CHANGELOG.md --next-tag `semtag final -s minor -o`
+
+release:
+	semtag final -s minor

--- a/README.md
+++ b/README.md
@@ -1,2 +1,137 @@
 # terraform-google-rad-security-connect
-A terraform module for allowing Rad Security to connect to your Google Cloud account.
+
+A Terraform module that establishes secure connectivity between your Google Cloud project and RAD Security's platform for cloud resource discovery and monitoring.
+
+## Overview
+
+This module creates and configures the necessary IAM roles and permissions to allow Rad Security to securely discover and monitor resources within your Google Cloud project. It utilizes Google Cloud's Workload Identity Federation to authenticate to your Google Cloud project without the need for creating static credentials.
+
+## Installation
+
+To use this module, add the following to your Terraform configuration:
+
+```hcl
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 4.0.0"
+    }
+    rad-security = {
+      source  = "rad-security/rad-security"
+      version = ">= 1.1.6"
+    }
+  }
+}
+
+provider "rad-security" {
+  access_key_id        = "YOUR_RAD_ACCESS_KEY_ID"
+  secret_key           = "YOUR_RAD_SECRET_KEY"
+}
+
+provider "google" {
+   // Your Google Cloud Terraform Provider configuration here
+}
+```
+
+## Features
+
+- Creates a custom IAM role with least-privilege permissions for cloud resource discovery
+- Sets up Workload Identity Federation for secure cross-cloud authentication
+- Configures service accounts and necessary bindings
+- Registers your Google Cloud project with RAD Security's platform
+
+## Important Notes
+
+- This module currently supports project-level access only
+- Organization-level support is not yet implemented
+- Uses AWS as the identity provider for Workload Identity Federation
+
+## How It Works
+
+1. Creates a custom IAM role with read-only permissions required for Google Cloud resource discovery.
+2. Sets up a Workload Identity Pool and Provider to authenticate RAD Security's AWS role for authentication.
+3. Creates a dedicated service account in the target Google Cloud project for RAD Security.
+4. Configures necessary IAM bindings between the service account and Workload Identity Pool
+5. Registers your Google Cloud project with RAD Security's platform
+
+## Configuration Options
+
+### Required Configuration
+- Configure your Google Cloud provider authentication
+- Ensure the necessary Google Cloud APIs are enabled:
+  - IAM API
+  - Cloud Resource Manager API
+  - Security Token Service API
+
+### Optional Parameters
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| gcp_project_name | Your GCP project name | Current project |
+| gcp_project_number | Your GCP project number | Current project |
+| aws_account_id | RAD Security's AWS account ID | 652031173150 |
+| aws_role_name | RAD Security's AWS Role Name | rad-security-connector |
+
+## Usage Examples
+
+### Basic Usage
+```hcl
+module "rad_security_connect" {
+  source = "rad-security/rad-security-connect/google"
+}
+```
+
+### Custom Project Configuration
+```hcl
+module "rad_security_connect" {
+  source             = "rad-security/rad-security-connect/google"
+  gcp_project_name   = "my-production-project"
+  gcp_project_number = "123456789012"
+}
+```
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.8 |
+| <a name="requirement_rad-security"></a> [rad-security](#requirement\_rad-security) | >= 1.1.6 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | n/a |
+| <a name="provider_rad-security"></a> [rad-security](#provider\_rad-security) | >= 1.1.6 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_iam_workload_identity_pool.rad_security_identity_pool](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/iam_workload_identity_pool) | resource |
+| [google_iam_workload_identity_pool_provider.rad_aws_provider](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/iam_workload_identity_pool_provider) | resource |
+| [google_project_iam_binding.rad_cloud_connect_access](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_binding) | resource |
+| [google_project_iam_custom_role.rad_cloud_connect](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role) | resource |
+| [google_service_account.rad_cloud_connect](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
+| [google_service_account_iam_binding.rad_workload_identity_user](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_binding) | resource |
+| [rad-security_google_cloud_register.this](https://registry.terraform.io/providers/rad-security/rad-security/latest/docs/resources/google_cloud_register) | resource |
+| [google_project.current](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/project) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_aws_account_id"></a> [aws\_account\_id](#input\_aws\_account\_id) | RAD Security's AWS account ID to authenticate with your Google Cloud project | `string` | `"652031173150"` | no |
+| <a name="input_aws_role_name"></a> [aws\_role\_name](#input\_aws\_role\_name) | RAD Security's AWS Role Name to authenticate with your Google Cloud project | `string` | `"rad-security-connector"` | no |
+| <a name="input_gcp_project_name"></a> [gcp\_project\_name](#input\_gcp\_project\_name) | GCP project name (optional - will use current project name if not specified) | `string` | `null` | no |
+| <a name="input_gcp_project_number"></a> [gcp\_project\_number](#input\_gcp\_project\_number) | GCP project number (optional - will use current project number if not specified) | `string` | `null` | no |
+
+## Outputs
+
+No outputs.
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/data.tf
+++ b/data.tf
@@ -1,0 +1,2 @@
+data "google_project" "current" {
+}

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -1,0 +1,29 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 4.0.0"
+    }
+    rad-security = {
+      source  = "rad-security/rad-security"
+      version = ">= 1.1.6"
+    }
+  }
+}
+
+provider "rad-security" {
+  access_key_id = var.rad_access_key_id
+  secret_key    = var.rad_secret_key
+}
+
+provider "google" {
+  // Your Google Cloud Terraform Provider configuration here
+}
+
+
+module "rad-security-connect" {
+  # https://registry.terraform.io/modules/rad-security/rad-security-connect/google/latest
+  source  = "rad-security/rad-security-connect/google"
+  version = "<version>"
+
+}

--- a/examples/basic/variables.tf
+++ b/examples/basic/variables.tf
@@ -1,0 +1,9 @@
+variable "rad_access_key_id" {
+  type        = string
+  description = "RAD API key"
+}
+
+variable "rad_secret_key" {
+  type        = string
+  description = "RAD API secret"
+}

--- a/locals.tf
+++ b/locals.tf
@@ -1,0 +1,4 @@
+locals {
+  project_name   = coalesce(var.gcp_project_name, data.google_project.current.name)
+  project_number = coalesce(var.gcp_project_number, data.google_project.current.number)
+}

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,66 @@
+resource "google_iam_workload_identity_pool" "rad_security_identity_pool" {
+  workload_identity_pool_id = "rad-security-identity-pool"
+  display_name              = "RAD Security Identity Pool"
+  description               = "Identity pool for RAD Security"
+}
+
+resource "google_iam_workload_identity_pool_provider" "rad_aws_provider" {
+  workload_identity_pool_id          = google_iam_workload_identity_pool.rad_security_identity_pool.workload_identity_pool_id
+  workload_identity_pool_provider_id = "rad-security-aws-provider"
+  display_name                       = "RAD Security AWS Provider"
+
+  attribute_mapping = {
+    "google.subject"        = "assertion.arn"
+    "attribute.aws_account" = "assertion.account"
+  }
+
+  attribute_condition = "assertion.account == '${var.aws_account_id}' && assertion.arn.contains('${var.aws_role_name}')"
+
+  aws {
+    account_id = var.aws_account_id
+  }
+}
+
+resource "google_service_account" "rad_cloud_connect" {
+  account_id   = "rad-security-cloud-connect"
+  display_name = "RAD Security Cloud Connect"
+}
+
+resource "google_service_account_iam_binding" "rad_workload_identity_user" {
+  service_account_id = google_service_account.rad_cloud_connect.id
+  role               = "roles/iam.workloadIdentityUser"
+
+  members = [
+    "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.rad_security_identity_pool.name}/attribute.aws_account/${var.aws_account_id}"
+  ]
+}
+
+resource "google_project_iam_custom_role" "rad_cloud_connect" {
+  project     = local.project_name
+  role_id     = "rad_security_cloud_connect_role_2"
+  title       = "RAD Security Cloud Connect Role"
+  description = "RAD Security's Google Cloud Role to retrieve Google Cloud resources"
+  permissions = [
+    "container.clusters.get",
+    "container.clusters.list"
+  ]
+}
+
+resource "google_project_iam_binding" "rad_cloud_connect_access" {
+  project = local.project_name
+  role    = google_project_iam_custom_role.rad_cloud_connect.id
+
+  members = [
+    "serviceAccount:${google_service_account.rad_cloud_connect.email}"
+  ]
+}
+
+resource "rad-security_google_cloud_register" "this" {
+  depends_on = [
+    google_project_iam_binding.rad_cloud_connect_access
+  ]
+
+  google_cloud_service_account_email = google_service_account.rad_cloud_connect.email
+  google_cloud_pool_provider_name    = google_iam_workload_identity_pool_provider.rad_aws_provider.name
+  google_cloud_project_number        = local.project_number
+}

--- a/main.tf
+++ b/main.tf
@@ -37,7 +37,7 @@ resource "google_service_account_iam_binding" "rad_workload_identity_user" {
 
 resource "google_project_iam_custom_role" "rad_cloud_connect" {
   project     = local.project_name
-  role_id     = "rad_security_cloud_connect_role_2"
+  role_id     = "rad_security_cloud_connect_role"
   title       = "RAD Security Cloud Connect Role"
   description = "RAD Security's Google Cloud Role to retrieve Google Cloud resources"
   permissions = [

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base"
+  ]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,21 @@
+variable "aws_account_id" {
+  description = "RAD Security's AWS account ID to authenticate with your Google Cloud project"
+  default     = "652031173150"
+}
+
+variable "aws_role_name" {
+  description = "RAD Security's AWS Role Name to authenticate with your Google Cloud project"
+  default     = "rad-security-connector"
+}
+
+variable "gcp_project_name" {
+  description = "GCP project name (optional - will use current project name if not specified)"
+  type        = string
+  default     = null
+}
+
+variable "gcp_project_number" {
+  description = "GCP project number (optional - will use current project number if not specified)"
+  type        = string
+  default     = null
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0.8"
+
+  required_providers {
+    rad-security = {
+      source  = "rad-security/rad-security"
+      version = ">= 1.1.6"
+    }
+  }
+}


### PR DESCRIPTION
Towards ENG-2129

Adds RAD Security's Google Cloud Connect Terraform Module. The module is currently only configured to work at the project level. Organization level scanning will be added at a later time. 