### PR TITLE
Fix: Use project_id instead of name for project lookup

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -1,4 +1,4 @@
 locals {
-  project_name   = coalesce(var.gcp_project_name, data.google_project.current.name)
+  project_name   = coalesce(var.gcp_project_name, data.google_project.current.project_id)
   project_number = coalesce(var.gcp_project_number, data.google_project.current.number)
 }


### PR DESCRIPTION
The module was using data.google_project.current.name which returns the project display name (e.g., "Acme Co") instead of the project ID (e.g., "acme-co").

This causes errors when the project display name contains spaces, as GCP IAM resources require the project ID format in resource paths.

Changed locals.tf to use data.google_project.current.project_id to ensure the correct identifier is used.

Fixes issues where terraform apply fails with:
"The role name must be in the form ... projects/{project_id}/roles/{role}"

🤖 Generated with Claude Code